### PR TITLE
Dockerfiles hinzugefügt

### DIFF
--- a/Open-Core/Dockerfile
+++ b/Open-Core/Dockerfile
@@ -1,0 +1,10 @@
+FROM openjdk:8-alpine
+MAINTAINER x7airworker
+
+RUN mkdir open-core
+
+COPY target/Open-Core-1.0-SNAPSHOT.jar open-core/
+
+WORKDIR open-core/
+
+CMD["java", "-jar", "Open-Core-1.0-SNAPSHOT.jar"]

--- a/Open-Master/Dockerfile
+++ b/Open-Master/Dockerfile
@@ -1,0 +1,10 @@
+FROM openjdk:8-alpine
+MAINTAINER x7airworker
+
+RUN mkdir open-master
+
+COPY target/Open-Master-1.0-SNAPSHOT.jar open-master/
+
+WORKDIR open-master/
+
+CMD["java", "-jar", "Open-Master-1.0-SNAPSHOT.jar"]

--- a/Open-Network/Dockerfile
+++ b/Open-Network/Dockerfile
@@ -1,0 +1,10 @@
+FROM openjdk:8-alpine
+MAINTAINER x7airworker
+
+RUN mkdir open-network
+
+COPY target/Open-Network-1.0-SNAPSHOT.jar open-network/
+
+WORKDIR open-network/
+
+CMD["java", "-jar", "Open-Network-1.0-SNAPSHOT.jar"]

--- a/Open-Wrapper/Dockerfile
+++ b/Open-Wrapper/Dockerfile
@@ -1,0 +1,10 @@
+FROM openjdk:8-alpine
+MAINTAINER x7airworker
+
+RUN mkdir open-wrapper
+
+COPY target/Open-Wrapper-1.0-SNAPSHOT.jar open-wrapper/
+
+WORKDIR open-wrapper/
+
+CMD["java", "-jar", "Open-Wrapper-1.0-SNAPSHOT.jar"]


### PR DESCRIPTION
Die Dockerfiles werden zur Nutzung des Cloud-Systemes in Docker-Containern benötigt.